### PR TITLE
Query failure rate

### DIFF
--- a/dsc-example-dashboards-2.0/DSC_examples_2.0_Statistics.json
+++ b/dsc-example-dashboards-2.0/DSC_examples_2.0_Statistics.json
@@ -1014,7 +1014,19 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [
+            {
+              "key": "server",
+              "value": "/^$server$/",
+              "operator": "=~"
+            },
+            {
+              "key": "node",
+              "value": "/^$node$/",
+              "operator": "=~",
+              "condition": "AND"
+            }
+          ]
         },
         {
           "datasource": {


### PR DESCRIPTION
- `dsc-example-dashboards-2.0`: Add missing where clauses for query A in query failure rate graph