### PR TITLE
Response Time fill

### DIFF
--- a/dsc-example-dashboards-2.0/DSC_examples_2.0_Statistics.json
+++ b/dsc-example-dashboards-2.0/DSC_examples_2.0_Statistics.json
@@ -1352,7 +1352,7 @@
             },
             {
               "params": [
-                "previous"
+                "none"
               ],
               "type": "fill"
             }


### PR DESCRIPTION
- `dsc-example-dashboards-2.0`: Fix response time graph, use `none` as fill instead of `previous`